### PR TITLE
Improve focus-out detection

### DIFF
--- a/jquery.timePicker.js
+++ b/jquery.timePicker.js
@@ -88,6 +88,17 @@
       if ($tpDiv.is(":visible")) {
         return false;
       }
+    
+      var clickOutListener=function(e) {
+        var contains=false;
+        $(e.target).parents().each(function() { contains|=(this===$tpDiv.first().get()); return contains; });
+        if (!contains) {
+          $tpDiv.hide();
+          $(document).undelegate("*", "click", clickOutListener);
+        }
+      };
+      $(document).delegate("*", "click", clickOutListener);
+
       $("li", $tpDiv).removeClass(selectedClass);
 
       // Position

--- a/jquery.timePicker.js
+++ b/jquery.timePicker.js
@@ -90,14 +90,16 @@
       }
     
       var clickOutListener=function(e) {
-        var contains=false;
+		var contains=false;
         $(e.target).parents().each(function() { contains|=(this===$tpDiv.first().get()); return contains; });
-        if (!contains) {
-          $tpDiv.hide();
-          $(document).undelegate("*", "click", clickOutListener);
+        contains|=(this===elm);
+		if (!contains) {
+			hidePicker($tpDiv);
         }
+		
       };
-      $(document).delegate("*", "click", clickOutListener);
+      $tpDiv.data("clickOutListener", clickOutListener);
+	  $(document).delegate("*", "click", clickOutListener);
 
       $("li", $tpDiv).removeClass(selectedClass);
 
@@ -131,7 +133,7 @@
     // Hide timepicker on blur
     $(elm).blur(function() {
       if (!tpOver) {
-        $tpDiv.hide();
+        hidePicker($tpDiv);
       }
     });
     // Keypress doesn't repeat on Safari for non-text keys.
@@ -193,7 +195,7 @@
           return false;
           break;
         case 27: // Esc
-          $tpDiv.hide();
+          hidePicker($tpDiv);
           return false;
           break;
       }
@@ -228,6 +230,13 @@
 
   // Private functions.
 
+  function hidePicker($tpDiv) {
+	var listener=$tpDiv.data("clickOutListener");
+	$(document).undelegate("*", "click", listener);
+	$tpDiv.removeData("clickOutListener");
+	$tpDiv.hide();
+  }
+
   function setTimeVal(elm, sel, $tpDiv, settings) {
     // Update input field
     elm.value = $(sel).text();
@@ -238,7 +247,7 @@
       elm.focus();
     }
     // Hide picker
-    $tpDiv.hide();
+    hidePicker($tpDiv);
   }
 
   function formatTime(time, settings) {


### PR DESCRIPTION
- Go to index html
- Click into the first field - timepicker opens
- Scroll the time picker using its scrollbar up or down
- Click somewhere outside the timepicker
- _Timepicker remains open_

The problem is that tpOver will remain true since no mouseout is received if the mouse moves from over the scrollbar out of the $tpDiv.

My fix is trivial. It listens for every click and if the clicked element is not a child of $tpDiv it closes the picker.
