### PR TITLE
Change the sole reference to jQuery to $ for consistency.  

### DIFF
--- a/jquery.timePicker.js
+++ b/jquery.timePicker.js
@@ -30,7 +30,7 @@
 
   $.timePicker = function (elm, settings) {
     var e = $(elm)[0];
-    return e.timePicker || (e.timePicker = new jQuery._timePicker(e, settings));
+    return e.timePicker || (e.timePicker = new $._timePicker(e, settings));
   };
 
   $.timePicker.version = '0.3';


### PR DESCRIPTION
Also, when using with a module loader, you get only one name or the other, not both jQuery and $.
