### PR TITLE
Made time conversion functions publicly accessible

### DIFF
--- a/jquery.timePicker.js
+++ b/jquery.timePicker.js
@@ -35,6 +35,20 @@
 
   $.timePicker.version = '0.3';
 
+  // Static public functions
+
+  // Date object to time string
+  $.timePicker.formatTime = function(val, settings) {
+    settings = $.extend({}, $.fn.timePicker.defaults, settings);
+    return formatTime(timeToDate(val, settings), settings);
+  };
+
+  // Time string to Date object
+  $.timePicker.timeStringToDate = function(str, settings) {
+    settings = $.extend({}, $.fn.timePicker.defaults, settings);
+    return timeStringToDate(str, settings);
+  };
+
   $._timePicker = function(elm, settings) {
 
     var tpOver = false;


### PR DESCRIPTION
Hi,

It's useful to be able to use the timePicker functions to be able to convert between the different time formats. I've exposed 2 private functions in this pull request. 

The jQuery UI datepicker works in a similar way (http://docs.jquery.com/UI/Datepicker/formatDate and http://docs.jquery.com/UI/Datepicker/parseDate).

Thanks,
Andrew
